### PR TITLE
Scaffold CarbonEye Agent prototype

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,51 @@
+# CarbonEye Agent Backend
+
+A FastAPI prototype that accepts GeoJSON geometries, orchestrates Google Earth Engine (GEE) calls, estimates biomass via
+AI/ML rules, and exposes reporting endpoints. The implementation is modular to support future integration with
+LLM-driven methodology selection and carbon credit registries (e.g., Verra, T-VER).
+
+## Running locally
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```
+
+## Key modules
+
+- `backend/main.py` — FastAPI app with `/calculate_carbon`, `/report/{job_id}`, `/health`
+- `backend/models/gee_client.py` — Earth Engine wrapper (mocked values with TODOs)
+- `backend/models/biomass_model.py` — Model selection + NDVI→biomass helpers
+- `backend/utils/carbon.py` — Conversion utilities and example carbon credit estimator
+- `backend/utils/geo.py` — GeoJSON area calculation using GeoPandas/Shapely
+- `backend/utils/reporting.py` — PDF report generator using ReportLab
+- `backend/agent/` — Prompt templates for the methodology LLM agent
+
+## Data flow (prototype)
+
+1. Frontend submits GeoJSON via `/calculate_carbon`
+2. Backend validates geometry and computes area (ha)
+3. Google Earth Engine client fetches NDVI/EVI + biomass rasters (mocked here)
+4. LLM/heuristics select biomass model coefficients (Tier 2 defaults)
+5. `estimate_carbon_from_indices` converts NDVI → biomass → carbon → CO₂e → credits
+6. Response cached and persisted as JSON; PDF report available at `/report/{job_id}?format=pdf`
+
+## Assumptions & limitations
+
+- Earth Engine integration returns mocked values; authentication + reducers must be implemented
+- Biomass conversion uses linear regression; calibrate with field plots / local allometric equations
+- Baseline deforestation rate fixed at 2% annually; replace with scenario modelling per standard
+- GeoPandas reprojects to EPSG:6933; ensure geometry boundaries fall within projection limits
+- ReportLab dependency is optional; switch to FPDF/WeasyPrint if preferred
+- No persistent database yet; replace in-memory cache with PostGIS + ledger integration
+
+## TODOs
+
+- [ ] Implement async Earth Engine data access with retries and cloud masking
+- [ ] Integrate LLM agent to reason about dataset/methodology selection
+- [ ] Persist job metadata + geometries in PostGIS
+- [ ] Add authentication + role-based access
+- [ ] Connect to carbon credit registries for verification workflows

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""CarbonEye backend package."""

--- a/backend/agent/__init__.py
+++ b/backend/agent/__init__.py
@@ -1,0 +1,1 @@
+"""LLM orchestration assets for CarbonEye."""

--- a/backend/agent/prompt_template.md
+++ b/backend/agent/prompt_template.md
@@ -1,0 +1,73 @@
+# CarbonEye Methodology Orchestration Prompt
+
+You are **CarbonEye Agent**, an expert carbon project analyst specialising in remote sensing and IPCC-aligned
+methodologies. Given project metadata and remote sensing diagnostics, you must select the optimal dataset, biomass
+conversion method, and crediting assumptions. Respond with JSON that downstream services can parse.
+
+## Input schema
+
+```json
+{
+  "project": {
+    "name": "Tropical Forest Conservation",
+    "country": "Brazil",
+    "ecosystem": "humid tropical forest",
+    "area_ha": 1250.4
+  },
+  "geometry_summary": {
+    "bbox": [minLon, minLat, maxLon, maxLat],
+    "area_ha": 1250.4
+  },
+  "remote_sensing": {
+    "ndvi_mean": 0.64,
+    "cloud_coverage": 0.12,
+    "available_datasets": ["COPERNICUS/S2_SR", "LANDSAT/LC09/C02/T1_L2", "ESA/BIOMASS/ALBE/V1"],
+    "recent_fires": false
+  },
+  "regulation": {
+    "target_standard": "Verra VCS",
+    "baseline_scenario": "unplanned deforestation"
+  }
+}
+```
+
+## Required reasoning steps
+
+1. Identify the most reliable optical and/or radar dataset(s) given ecosystem, cloud cover, and revisit needs.
+2. Select biomass estimation approach (e.g., IPCC Tier 1 default factors, Tier 2 regression, Tier 3 ML) and justify.
+3. Determine how to handle data gaps (clouds, missing scenes) and whether to fuse datasets.
+4. Compute/assume baseline degradation rate consistent with the requested standard.
+5. Output transparent metadata including sources, coefficients, and QA notes.
+
+## Output schema
+
+```json
+{
+  "dataset": {
+    "primary": "COPERNICUS/S2_SR",
+    "secondary": ["ESA/BIOMASS/ALBE/V1"],
+    "cloud_handling": "Apply s2cloudless mask, fallback to Landsat 8 when coverage < 70%"
+  },
+  "methodology": {
+    "name": "IPCC 2006 Tier 2",
+    "biomass_coefficients": {"slope": 175.0, "intercept": 30.0},
+    "source_reference": "IPCC 2006 AFOLU Guidelines, Table 4.7",
+    "llm_confidence": 0.82
+  },
+  "baseline": {
+    "scenario": "unplanned deforestation",
+    "annual_degradation_rate": 0.021,
+    "evidence": "Historical Hansen Global Forest Change loss 2015-2020"
+  },
+  "qa_notes": [
+    "Check ESA Biomass scene IDs for acquisition date overlap",
+    "Validate regression coefficients against local NFI plots"
+  ]
+}
+```
+
+## Style guidelines
+
+- Think step-by-step; explain reasoning before JSON output using bullet points.
+- Output final JSON in a fenced code block labelled `json`.
+- If information is missing, state assumptions explicitly in `qa_notes`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,139 @@
+"""FastAPI backend for the CarbonEye Agent."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import uuid
+from pathlib import Path
+from typing import Any, Dict
+
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel, Field
+
+from backend.models.biomass_model import BiomassModelConfig, choose_model
+from backend.models.gee_client import EarthEngineClient
+from backend.utils.carbon import BiomassEstimation, estimate_carbon_from_indices
+from backend.utils.geo import geojson_area_hectares
+from backend.utils.reporting import ReportPayload, build_pdf_report
+
+RESULT_CACHE: Dict[str, Dict[str, Any]] = {}
+REPORTS_DIR = Path("reports")
+REPORTS_DIR.mkdir(exist_ok=True)
+
+app = FastAPI(title="CarbonEye Agent API", version="0.1.0")
+app.add_middleware(
+  CORSMiddleware,
+  allow_origins=["*"],
+  allow_methods=["*"],
+  allow_headers=["*"]
+)
+
+
+class GeometryPayload(BaseModel):
+  geometry: Dict[str, Any] = Field(..., description="GeoJSON geometry or FeatureCollection")
+  project_name: str = Field("Untitled project")
+  start_date: dt.date | None = Field(default=None)
+  end_date: dt.date | None = Field(default=None)
+
+
+class CarbonResult(BaseModel):
+  job_id: str
+  biomass: float
+  carbon_stock: float
+  co2e: float
+  credits: float
+  metadata: Dict[str, Any]
+
+
+@app.post("/calculate_carbon", response_model=CarbonResult)
+async def calculate_carbon(payload: GeometryPayload) -> CarbonResult:
+  """Ingest polygon, query GEE + ML, and return carbon metrics."""
+
+  geometry = payload.geometry
+  try:
+    area_hectares = geojson_area_hectares(geometry)
+  except ValueError as exc:
+    raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+  client = EarthEngineClient()
+  start_date = payload.start_date or (dt.date.today() - dt.timedelta(days=365))
+  end_date = payload.end_date or dt.date.today()
+  ndvi_series = client.fetch_ndvi_series(geometry, start_date, end_date)
+
+  model_config: BiomassModelConfig = choose_model({
+    "region": "tropical",
+    "dataset": "Sentinel-2",
+    "llm_reasoning": "TODO: Replace with agent call"
+  })
+
+  estimation: BiomassEstimation = estimate_carbon_from_indices(
+    ndvi_series,
+    area_hectares,
+    biomass_coefficients=model_config.ndvi_to_biomass_coefficients,
+  )
+
+  job_id = uuid.uuid4().hex
+  result_payload = {
+    "job_id": job_id,
+    "biomass": estimation.biomass,
+    "carbon_stock": estimation.carbon_stock,
+    "co2e": estimation.co2e,
+    "credits": estimation.credits,
+    "metadata": {
+      **estimation.metadata,
+      "model": model_config.__dict__,
+      "ndvi_series": ndvi_series,
+      "start_date": start_date.isoformat(),
+      "end_date": end_date.isoformat(),
+      "project_name": payload.project_name,
+      "area_hectares": area_hectares,
+    }
+  }
+
+  RESULT_CACHE[job_id] = result_payload
+  (REPORTS_DIR / f"{job_id}.json").write_text(json.dumps(result_payload, indent=2))
+
+  return CarbonResult(**result_payload)
+
+
+@app.get("/report/{job_id}")
+async def get_report(job_id: str, format: str = Query("json", pattern="^(json|pdf)$")) -> Response:
+  """Return stored report in JSON or PDF format."""
+
+  if job_id not in RESULT_CACHE:
+    raise HTTPException(status_code=404, detail="Unknown job id")
+
+  record = RESULT_CACHE[job_id]
+
+  if format == "json":
+    return JSONResponse(record)
+
+  payload = ReportPayload(
+    job_id=job_id,
+    project_name=record["metadata"].get("project_name", "Untitled project"),
+    metrics={
+      "Biomass (t)": f"{record['biomass']:.2f}",
+      "Carbon stock (t C)": f"{record['carbon_stock']:.2f}",
+      "CO₂e (t)": f"{record['co2e']:.2f}",
+      "Credits/year (tCO₂e)": f"{record['credits']:.2f}",
+    },
+    metadata=record["metadata"],
+  )
+  pdf_bytes = build_pdf_report(payload)
+
+  return Response(content=pdf_bytes, media_type="application/pdf")
+
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+  """Health probe for uptime checks."""
+
+  return {"status": "ok"}
+
+
+@app.get("/")
+async def root() -> Dict[str, str]:
+  return {"message": "CarbonEye Agent API"}

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,11 @@
+"""Model utilities for CarbonEye backend."""
+
+from .biomass_model import BiomassModelConfig, choose_model, predict_biomass
+from .gee_client import EarthEngineClient
+
+__all__ = [
+  "BiomassModelConfig",
+  "choose_model",
+  "predict_biomass",
+  "EarthEngineClient",
+]

--- a/backend/models/biomass_model.py
+++ b/backend/models/biomass_model.py
@@ -1,0 +1,45 @@
+"""Machine learning utilities for biomass estimation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+import numpy as np
+
+
+@dataclass
+class BiomassModelConfig:
+  name: str
+  version: str
+  ndvi_to_biomass_coefficients: tuple[float, float]
+  source: str
+
+
+def choose_model(metadata: Dict[str, str]) -> BiomassModelConfig:
+  """Pick a biomass model configuration based on metadata.
+
+  In production this should rely on the LLM agent's reasoning. For the prototype we return
+  a fixed configuration representing an IPCC Tier 2 linear regression.
+  """
+
+  _ = metadata
+  return BiomassModelConfig(
+    name="ipcc-tier2-linear",
+    version="0.1.0",
+    ndvi_to_biomass_coefficients=(175.0, 30.0),
+    source="Derived from IPCC 2006 guidelines - humid tropical forest default",
+  )
+
+
+def predict_biomass(ndvi_series: List[float], coefficients: tuple[float, float]) -> float:
+  """Return biomass per hectare from NDVI observations using linear regression."""
+
+  if not ndvi_series:
+    raise ValueError("NDVI series cannot be empty")
+
+  slope, intercept = coefficients
+  return float(np.mean(ndvi_series) * slope + intercept)
+
+
+__all__ = ["BiomassModelConfig", "choose_model", "predict_biomass"]

--- a/backend/models/gee_client.py
+++ b/backend/models/gee_client.py
@@ -1,0 +1,46 @@
+"""Google Earth Engine integration layer.
+
+This module wraps the Earth Engine client. It is intentionally light-weight and contains TODOs where
+project-specific logic should be implemented."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Dict, List
+
+
+class EarthEngineClient:
+  """Facade over the Google Earth Engine Python API."""
+
+  def __init__(self, *, project: str | None = None):
+    self.project = project
+    # TODO: initialise ee.Authenticate() / ee.Initialize(project=project)
+
+  def fetch_ndvi_series(
+    self,
+    geometry: Dict[str, Any],
+    start_date: dt.date,
+    end_date: dt.date,
+    dataset: str = "COPERNICUS/S2_SR",
+  ) -> List[float]:
+    """Return NDVI measurements for the provided geometry.
+
+    This prototype returns mocked values. Replace with Earth Engine reducers.
+    """
+
+    # TODO: Use ee.ImageCollection(dataset).filterDate(...).filterBounds(...)
+    #       .map(cloud_mask).map(calculate_ndvi) and reduceRegion/reduceColumns
+    _ = (geometry, start_date, end_date, dataset)
+    return [0.62, 0.65, 0.61, 0.58]
+
+  def fetch_biomass_raster(self, geometry: Dict[str, Any], dataset: str = "ESA/BIOMASS/ALBE/V1") -> float:
+    """Sample biomass raster to approximate AGB in t/ha.
+
+    TODO: Implement ee.Image(dataset).sample()
+    """
+
+    _ = (geometry, dataset)
+    return 130.0
+
+
+__all__ = ["EarthEngineClient"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,11 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+pydantic==2.6.4
+httpx==0.27.0
+python-dotenv==1.0.1
+geopandas==0.14.3
+shapely==2.0.3
+pandas==2.2.1
+numpy==1.26.4
+reportlab==4.0.7
+openpyxl==3.1.2

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,0 +1,20 @@
+"""Utility helpers for CarbonEye backend."""
+
+from .carbon import (
+  BiomassEstimation,
+  biomass_to_carbon,
+  carbon_to_co2e,
+  estimate_carbon_from_indices,
+)
+from .geo import geojson_area_hectares
+from .reporting import ReportPayload, build_pdf_report
+
+__all__ = [
+  "BiomassEstimation",
+  "biomass_to_carbon",
+  "carbon_to_co2e",
+  "estimate_carbon_from_indices",
+  "geojson_area_hectares",
+  "ReportPayload",
+  "build_pdf_report",
+]

--- a/backend/utils/carbon.py
+++ b/backend/utils/carbon.py
@@ -1,0 +1,90 @@
+"""Carbon and biomass conversion utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+CARBON_FRACTION = 0.47
+CO2E_CONVERSION = 3.67
+
+
+def biomass_to_carbon(biomass_tonnes: float) -> float:
+  """Convert above ground biomass (tonnes) to tonnes of carbon."""
+
+  return biomass_tonnes * CARBON_FRACTION
+
+
+def carbon_to_co2e(carbon_tonnes: float) -> float:
+  """Convert tonnes of carbon to tonnes of CO₂ equivalent."""
+
+  return carbon_tonnes * CO2E_CONVERSION
+
+
+@dataclass
+class BiomassEstimation:
+  """Result of biomass estimation."""
+
+  biomass: float
+  carbon_stock: float
+  co2e: float
+  credits: float
+  metadata: Dict[str, object]
+
+
+def estimate_carbon_from_indices(
+  ndvi_series: List[float],
+  area_hectares: float,
+  biomass_coefficients: Tuple[float, float] = (150, 50),
+  baseline_degradation_rate: float = 0.02,
+) -> BiomassEstimation:
+  """Estimate carbon metrics from NDVI observations.
+
+  Args:
+      ndvi_series: Historical NDVI values (cloud-filtered).
+      area_hectares: Project area in hectares.
+      biomass_coefficients: Tuple (slope, intercept) for NDVI→biomass regression (t/ha).
+      baseline_degradation_rate: Annual percent biomass loss without intervention.
+  """
+
+  if not ndvi_series:
+    raise ValueError("NDVI series required for carbon estimation")
+
+  slope, intercept = biomass_coefficients
+  ndvi_array = np.array(ndvi_series)
+  biomass_per_hectare = slope * ndvi_array.mean() + intercept
+  biomass_total = biomass_per_hectare * area_hectares
+  carbon_stock = biomass_to_carbon(biomass_total)
+  co2e = carbon_to_co2e(carbon_stock)
+
+  avoided_emissions = biomass_total * baseline_degradation_rate
+  credits = carbon_to_co2e(biomass_to_carbon(avoided_emissions))
+
+  metadata = {
+    "ndvi_mean": float(ndvi_array.mean()),
+    "ndvi_observations": len(ndvi_series),
+    "biomass_coefficients": {
+      "slope": slope,
+      "intercept": intercept,
+    },
+    "baseline_degradation_rate": baseline_degradation_rate,
+    "area_hectares": area_hectares,
+  }
+
+  return BiomassEstimation(
+    biomass=biomass_total,
+    carbon_stock=carbon_stock,
+    co2e=co2e,
+    credits=credits,
+    metadata=metadata,
+  )
+
+
+__all__ = [
+  "BiomassEstimation",
+  "biomass_to_carbon",
+  "carbon_to_co2e",
+  "estimate_carbon_from_indices",
+]

--- a/backend/utils/examples/__init__.py
+++ b/backend/utils/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example scripts for CarbonEye backend utilities."""

--- a/backend/utils/examples/carbon_calculation_example.py
+++ b/backend/utils/examples/carbon_calculation_example.py
@@ -1,0 +1,32 @@
+"""Runnable example demonstrating carbon credit estimation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from backend.utils.carbon import estimate_carbon_from_indices
+
+
+if __name__ == "__main__":
+  ndvi_series = [0.62, 0.64, 0.60, 0.59, 0.63]
+  area_hectares = 150.0
+
+  estimation = estimate_carbon_from_indices(
+    ndvi_series,
+    area_hectares,
+    biomass_coefficients=(175.0, 30.0),
+    baseline_degradation_rate=0.02,
+  )
+
+  result = {
+    "biomass_tonnes": round(estimation.biomass, 2),
+    "carbon_stock_tonnes": round(estimation.carbon_stock, 2),
+    "co2e_tonnes": round(estimation.co2e, 2),
+    "credits_per_year": round(estimation.credits, 2),
+    "metadata": estimation.metadata,
+  }
+
+  output_path = Path(__file__).parent / "carbon_estimate.json"
+  output_path.write_text(json.dumps(result, indent=2))
+  print(f"Wrote example estimation to {output_path}")

--- a/backend/utils/geo.py
+++ b/backend/utils/geo.py
@@ -1,0 +1,41 @@
+"""Utility helpers for working with GeoJSON geometries."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import geopandas as gpd
+from shapely.geometry import shape
+
+
+def geojson_area_hectares(geometry: Dict[str, Any]) -> float:
+  """Return the area of a GeoJSON geometry in hectares.
+
+  Args:
+      geometry: A GeoJSON FeatureCollection or geometry dictionary.
+
+  Returns:
+      The area in hectares.
+
+  Notes:
+      Uses GeoPandas to project the geometry to an equal-area CRS (World Cylindrical Equal Area).
+  """
+
+  if "type" not in geometry:
+    raise ValueError("Invalid GeoJSON: missing type field")
+
+  if geometry["type"] == "FeatureCollection":
+    if not geometry.get("features"):
+      raise ValueError("FeatureCollection must contain at least one feature")
+    geom = shape(geometry["features"][0]["geometry"])
+  elif geometry["type"] == "Feature":
+    geom = shape(geometry["geometry"])
+  else:
+    geom = shape(geometry)
+
+  gdf = gpd.GeoDataFrame(geometry=[geom], crs="EPSG:4326").to_crs("EPSG:6933")
+  area_sq_m = float(gdf.area.iloc[0])
+  return area_sq_m / 10_000
+
+
+__all__ = ["geojson_area_hectares"]

--- a/backend/utils/reporting.py
+++ b/backend/utils/reporting.py
@@ -1,0 +1,48 @@
+"""PDF and JSON reporting helpers."""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer
+
+
+@dataclass
+class ReportPayload:
+  job_id: str
+  project_name: str
+  metrics: Dict[str, Any]
+  metadata: Dict[str, Any]
+
+
+def build_pdf_report(payload: ReportPayload) -> bytes:
+  """Generate a simple PDF summarising the carbon accounting output."""
+
+  buffer = io.BytesIO()
+  doc = SimpleDocTemplate(buffer, pagesize=A4, title="CarbonEye Agent Report")
+  styles = getSampleStyleSheet()
+  story = []
+
+  story.append(Paragraph("<b>CarbonEye Agent</b> — Remote carbon stock analysis", styles["Title"]))
+  story.append(Spacer(1, 12))
+  story.append(Paragraph(f"Job ID: {payload.job_id}", styles["Normal"]))
+  story.append(Paragraph(f"Project: {payload.project_name}", styles["Normal"]))
+  story.append(Spacer(1, 12))
+  story.append(Paragraph("<b>Key metrics</b>", styles["Heading2"]))
+
+  for key, value in payload.metrics.items():
+    story.append(Paragraph(f"{key}: {value}", styles["Normal"]))
+
+  story.append(Spacer(1, 12))
+  story.append(Paragraph("<b>Metadata</b>", styles["Heading2"]))
+  story.append(Paragraph("<font size=9>" + repr(payload.metadata) + "</font>", styles["Normal"]))
+
+  doc.build(story)
+  return buffer.getvalue()
+
+
+__all__ = ["ReportPayload", "build_pdf_report"]

--- a/docs/system-diagram.md
+++ b/docs/system-diagram.md
@@ -1,0 +1,43 @@
+# CarbonEye Agent — System Diagram
+
+```mermaid
+flowchart LR
+  subgraph Frontend
+    UI[Leaflet Map UI]
+    Draw[Polygon Drawing]
+  end
+
+  subgraph Backend
+    API[FastAPI `/calculate_carbon`]
+    Agent[LLM Methodology Agent]
+    GEE[Earth Engine Client]
+    Model[Biomass/Carbon Model]
+    Report[Report Generator]
+  end
+
+  subgraph DataStores
+    PostGIS[(PostGIS / Spatial DB)]
+    Ledger[(Verification Ledger)]
+    Reports[(JSON/PDF Reports)]
+  end
+
+  UI -->|GeoJSON POST| API
+  Draw --> UI
+  API -->|Invoke| Agent
+  API -->|Request NDVI/EVI| GEE
+  GEE -->|Indices & Biomass Layers| Model
+  Agent -->|Method config| Model
+  Model -->|Biomass/Carbon Metrics| API
+  API --> Reports
+  API -->|Persist| PostGIS
+  Reports --> Ledger
+  Reports -->|Download| UI
+```
+
+**Data flow summary**
+
+1. Users draw/upload polygons in the Leaflet UI and submit GeoJSON to the API.
+2. FastAPI validates geometry, computes area, and coordinates Earth Engine + ML calls.
+3. The LLM agent selects methodologies, datasets, and conversion factors.
+4. Biomass model converts NDVI/EVI + auxiliary biomass data into carbon stock and CO₂e.
+5. Results are cached, persisted, and available via JSON/PDF reports, ready for carbon market verification.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,42 @@
+# CarbonEye Agent Frontend
+
+This folder contains a minimal **Next.js 14** prototype with **Leaflet** map tooling for the CarbonEye Agent. It enables
+users to digitise a project area, export it as GeoJSON, and call the backend carbon accounting API.
+
+## Key features
+
+- Leaflet map with drawing controls (polygon + rectangle)
+- Client-side GeoJSON state management and POST request to the backend
+- Result panel surfacing biomass/carbon/credit metrics and metadata
+- Modular component structure that can scale into a dashboard
+
+## Getting started
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The app assumes the backend FastAPI server runs on `http://localhost:8000`. Override this by setting
+`NEXT_PUBLIC_API_BASE_URL` in a `.env.local` file.
+
+## Directory structure
+
+```
+frontend/
+├── package.json
+├── next.config.mjs
+├── src/
+│   ├── app/page.tsx          # Marketing copy + map component
+│   ├── components/CarbonMap.tsx
+│   └── lib/api.ts            # Shared fetch helper
+└── README.md
+```
+
+## TODOs
+
+- [ ] Add authentication and project management UI
+- [ ] Support uploading existing shapefiles/GeoJSON files
+- [ ] Integrate charts for time-series NDVI/EVI visualisation
+- [ ] Persist map state and recent analyses

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "carbon-eye-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "leaflet": "^1.9.4",
+    "next": "^14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-leaflet": "^4.2.1",
+    "react-leaflet-draw": "^0.20.1"
+  },
+  "devDependencies": {
+    "@types/geojson": "^7946.0.10",
+    "@types/leaflet": "^1.9.9",
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.54",
+    "@types/react-dom": "^18.2.18",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "^14.2.0",
+    "postcss": "^8.4.32",
+    "typescript": "^5.4.2"
+  }
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,22 @@
+import dynamic from "next/dynamic";
+
+const CarbonMap = dynamic(() => import("@/components/CarbonMap"), {
+  ssr: false
+});
+
+export default function HomePage() {
+  return (
+    <main className="mx-auto max-w-6xl space-y-8 p-6">
+      <header className="space-y-2">
+        <p className="text-sm uppercase tracking-wide text-emerald-700">CarbonEye Agent</p>
+        <h1 className="text-3xl font-bold text-slate-900">Monitor carbon and biomass from satellite imagery</h1>
+        <p className="max-w-3xl text-sm text-slate-600">
+          Draw or upload a project boundary to trigger the AI-driven workflow. The map captures your area,
+          the backend orchestrates Google Earth Engine, biomass modelling, and carbon credit estimation, and the
+          dashboard returns transparent metrics and metadata.
+        </p>
+      </header>
+      <CarbonMap />
+    </main>
+  );
+}

--- a/frontend/src/components/CarbonMap.tsx
+++ b/frontend/src/components/CarbonMap.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import "leaflet/dist/leaflet.css";
+import "leaflet-draw/dist/leaflet.draw.css";
+
+import { useCallback, useMemo, useState } from "react";
+import { FeatureGroup, MapContainer, TileLayer } from "react-leaflet";
+import { EditControl } from "react-leaflet-draw";
+import L, { LeafletMouseEvent } from "leaflet";
+import type { FeatureCollection, Polygon } from "geojson";
+
+interface CarbonMapProps {
+  readonly apiBaseUrl?: string;
+}
+
+interface CarbonResponse {
+  biomass: number;
+  carbon_stock: number;
+  co2e: number;
+  credits: number;
+  metadata: Record<string, unknown>;
+}
+
+const DEFAULT_CENTER: [number, number] = [0, 0];
+const DEFAULT_ZOOM = 4;
+
+export function CarbonMap({ apiBaseUrl = "http://localhost:8000" }: CarbonMapProps) {
+  const [geojson, setGeojson] = useState<FeatureCollection<Polygon> | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<CarbonResponse | null>(null);
+
+  const handleCreated = useCallback((event: L.LeafletEvent) => {
+    const layer = (event as unknown as { layer: L.Layer }).layer;
+    if (layer instanceof L.Polygon || layer instanceof L.Rectangle) {
+      const feature = layer.toGeoJSON() as FeatureCollection<Polygon>;
+      setGeojson(feature);
+      setResult(null);
+      setError(null);
+    }
+  }, []);
+
+  const handleDeleted = useCallback(() => {
+    setGeojson(null);
+    setResult(null);
+    setError(null);
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (!geojson) {
+      setError("Draw a polygon before requesting a calculation.");
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/calculate_carbon`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ geometry: geojson })
+      });
+
+      if (!response.ok) {
+        throw new Error(`API responded with ${response.status}`);
+      }
+
+      const payload: CarbonResponse = await response.json();
+      setResult(payload);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [apiBaseUrl, geojson]);
+
+  const handleClick = useCallback((event: LeafletMouseEvent) => {
+    console.debug("Clicked coordinates", event.latlng);
+  }, []);
+
+  const editHandlers = useMemo(
+    () => ({
+      edit: {
+        selectedPathOptions: {
+          maintainColor: true
+        }
+      },
+      remove: {}
+    }),
+    []
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="h-[60vh] w-full rounded-lg border border-slate-200">
+        <MapContainer
+          center={DEFAULT_CENTER}
+          zoom={DEFAULT_ZOOM}
+          className="h-full w-full"
+          scrollWheelZoom
+          whenCreated={(map) => map.on("click", handleClick)}
+        >
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <FeatureGroup>
+            <EditControl
+              position="topright"
+              onCreated={handleCreated}
+              onDeleted={handleDeleted}
+              draw={{
+                polyline: false,
+                circle: false,
+                circlemarker: false,
+                marker: false,
+                polygon: true,
+                rectangle: true
+              }}
+              edit={editHandlers.edit}
+              remove={editHandlers.remove}
+            />
+          </FeatureGroup>
+        </MapContainer>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          onClick={handleSubmit}
+          className="rounded bg-emerald-600 px-4 py-2 font-semibold text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={isLoading}
+        >
+          {isLoading ? "Calculating…" : "Calculate carbon"}
+        </button>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </div>
+
+      {result && (
+        <div className="rounded border border-slate-200 bg-white p-4 shadow-sm">
+          <h2 className="text-lg font-semibold">Estimated carbon metrics</h2>
+          <ul className="mt-2 space-y-1 text-sm text-slate-700">
+            <li><strong>Biomass:</strong> {result.biomass.toLocaleString()} t/ha</li>
+            <li><strong>Carbon stock:</strong> {result.carbon_stock.toLocaleString()} t C</li>
+            <li><strong>CO₂e:</strong> {result.co2e.toLocaleString()} t CO₂e</li>
+            <li><strong>Credits/year:</strong> {result.credits.toLocaleString()} tCO₂e</li>
+          </ul>
+          <details className="mt-3 text-sm">
+            <summary className="cursor-pointer font-medium">Metadata</summary>
+            <pre className="mt-2 overflow-x-auto rounded bg-slate-50 p-3 text-xs text-slate-600">
+              {JSON.stringify(result.metadata, null, 2)}
+            </pre>
+          </details>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default CarbonMap;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,22 @@
+export interface CarbonCalculationRequest {
+  geometry: GeoJSON.FeatureCollection<GeoJSON.Polygon>;
+}
+
+export async function calculateCarbon(
+  request: CarbonCalculationRequest,
+  apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000"
+) {
+  const response = await fetch(`${apiBaseUrl}/calculate_carbon`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(request)
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to calculate carbon: ${response.status}`);
+  }
+
+  return response.json();
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["src/components/*"],
+      "@/lib/*": ["src/lib/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js + Leaflet frontend scaffold for drawing polygons and calling the carbon API
- implement FastAPI backend skeleton with mocked Earth Engine client, carbon conversions, and PDF reporting
- provide LLM agent prompt, carbon calculation example script, and system diagram documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901d359d3108330b2a0a2a9e0c4ecad